### PR TITLE
Bump reflex-platform to get an 0.6-series reflex

### DIFF
--- a/nix/reflex-platform.json
+++ b/nix/reflex-platform.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/reflex-frp/reflex-platform",
-  "rev": "f22f76cadf26de49f072b4b2565956ffbdd03819",
-  "date": "2019-03-17T11:09:59-04:00",
-  "sha256": "14ksx6li4ppzahfh398vv5jgw6j40qfncrk2jy0s1jkvxghc49sm",
+  "rev": "beaa34d244176fc2ff8f70642812141eaf3e559b",
+  "date": "2019-05-16T11:37:55-04:00",
+  "sha256": "1sfibav817qpvw8j4fm1jx4m2dvb3a5ra8j2ff6hc8w18i9j0ig4",
   "fetchSubmodules": false
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,3 +1,4 @@
-#! /usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-prefetch-git
 
 nix-prefetch-git https://github.com/reflex-frp/reflex-platform > reflex-platform.json


### PR DESCRIPTION
I want to relax reflex bounds on reflex-backend-socket, and I can't do that until this is bumped also.