### PR TITLE
Tweak repeatUntilQuit to return an Event, define repeatUntilQuit_

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 0.2
 
+* Added `Reflex.Host.Basic.repeatUntilQuit_`, with the same behaviour
+  as 0.1's `Reflex.Host.Basic.repeatUntilQuit`.
+* `Reflex.Host.Basic.repeatUntilQuit` now returns an `Event` that
+  fires each time the action executes. If you don't need this,
+  consider `Reflex.Host.Basic.repeatUntilQuit_`.
 * `Reflex.Host.Basic.basicHostWithQuit`: Expect a guest that returns
   only `Event t ()`, as trying to return an actual result gives
   hard-to-diagnose type errors at the use site and most people

--- a/example/Counter.hs
+++ b/example/Counter.hs
@@ -1,9 +1,13 @@
-{-# language FlexibleContexts, TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecursiveDo      #-}
+{-# LANGUAGE TypeFamilies     #-}
+
 module Main where
 
 import Control.Concurrent (threadDelay)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (liftIO)
+import Data.Functor (void)
 import Reflex
 import Reflex.Host.Basic
 
@@ -14,13 +18,13 @@ myNetwork
 myNetwork = count
 
 myGuest :: BasicGuestConstraints t m => BasicGuest t m (Event t ())
-myGuest = do
-  (eTick, sendTick) <- newTriggerEvent
-  dCount <- myNetwork eTick
+myGuest = mdo
+  eTick <- repeatUntilQuit (void $ threadDelay 1000000) eQuit
   let
     eCountUpdated = updated dCount
     eQuit = () <$ ffilter (==5) eCountUpdated
-  repeatUntilQuit (threadDelay 1000000 *> sendTick ()) eQuit
+  dCount <- myNetwork eTick
+
   performEvent_ $ liftIO . print <$> eCountUpdated
   pure eQuit
 


### PR DESCRIPTION
Closes #10.

Unsure if `repeatUntilQuit` even belongs in this library; it feels like a random utility rather than core part of host services.

Also, are there efficiency losses if we define `repeatUntilQuit_` in terms of `void` and `repeatUntilQuit`?